### PR TITLE
add json endpoint with image urls for startpage

### DIFF
--- a/app/Resources/templates/pages/homepage.xml
+++ b/app/Resources/templates/pages/homepage.xml
@@ -39,5 +39,47 @@
                 </property>
             </properties>
         </section>
+
+        <property name="animation_background_1" type="media_selection">
+            <meta>
+                <title lang="en">Background Animation 1</title>
+                <title lang="de">Hintergrund Animation 1</title>
+            </meta>
+            <params>
+                <param name="type" value="image"/>
+                <param name="displayOptions" type="collection">
+                    <param name="leftTop" value="false"/>
+                    <param name="top" value="false"/>
+                    <param name="rightTop" value="false"/>
+                    <param name="left" value="false"/>
+                    <param name="middle" value="false"/>
+                    <param name="right" value="false"/>
+                    <param name="leftBottom" value="false"/>
+                    <param name="bottom" value="false"/>
+                    <param name="rightBottom" value="false"/>
+                </param>
+            </params>
+        </property>
+
+        <property name="animation_background_2" type="media_selection">
+            <meta>
+                <title lang="en">Background Animation 2</title>
+                <title lang="de">Hintergrund Animation 2</title>
+            </meta>
+            <params>
+                <param name="type" value="image"/>
+                <param name="displayOptions" type="collection">
+                    <param name="leftTop" value="false"/>
+                    <param name="top" value="false"/>
+                    <param name="rightTop" value="false"/>
+                    <param name="left" value="false"/>
+                    <param name="middle" value="false"/>
+                    <param name="right" value="false"/>
+                    <param name="leftBottom" value="false"/>
+                    <param name="bottom" value="false"/>
+                    <param name="rightBottom" value="false"/>
+                </param>
+            </params>
+        </property>
     </properties>
 </template>

--- a/app/Resources/views/templates/homepage.json.twig
+++ b/app/Resources/views/templates/homepage.json.twig
@@ -1,3 +1,23 @@
+{% if content.animation_background_1|length > 0 %}
+{% set animationBackground1 = content.animation_background_1[0].formats %}
+{% endif %}
+{% if content.animation_background_2|length > 0 %}
+{% set animationBackground2 = content.animation_background_2[0].formats %}
+{% endif %}
 {
-    "title": "{{ content.title }}"
+    "title": "{{ content.title }}",
+    "animationBackground1": {
+        {% if animationBackground1 is defined %}
+        "small": "{{ absolute_url(animationBackground1['1000x']) }}",
+        "medium": "{{ absolute_url(animationBackground1['2000x']) }}",
+        "large": "{{ absolute_url(animationBackground1['3000x']) }}"
+        {% endif %}
+    },
+    "animationBackground2": {
+        {% if animationBackground2 is defined %}
+        "small": "{{ absolute_url(animationBackground2['1000x']) }}",
+        "medium": "{{ absolute_url(animationBackground2['2000x']) }}",
+        "large": "{{ absolute_url(animationBackground2['3000x']) }}"
+        {% endif %}
+    }
 }

--- a/app/Resources/webspaces/agent18.xml
+++ b/app/Resources/webspaces/agent18.xml
@@ -4,7 +4,7 @@
           xsi:schemaLocation="http://schemas.sulu.io/webspace/webspace http://schemas.sulu.io/webspace/webspace-1.1.xsd">
 
     <name>AgentConf</name>
-    <key>agent</key>
+    <key>agent18</key>
 
     <localizations>
         <localization language="en" default="true"/>

--- a/app/config/image-formats.xml
+++ b/app/config/image-formats.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<formats xmlns="http://schemas.sulu.io/media/formats"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://schemas.sulu.io/media/formats http://schemas.sulu.io/media/formats-1.0.xsd">
+    <format>
+        <name>3000x</name>
+        <commands>
+            <command>
+                <action>resize</action>
+                <parameters>
+                    <parameter name="x">3000</parameter>
+                </parameters>
+            </command>
+        </commands>
+    </format>
+    <format>
+        <name>2000x</name>
+        <commands>
+            <command>
+                <action>resize</action>
+                <parameters>
+                    <parameter name="x">2000</parameter>
+                </parameters>
+            </command>
+        </commands>
+    </format>
+    <format>
+        <name>1000x</name>
+        <commands>
+            <command>
+                <action>resize</action>
+                <parameters>
+                    <parameter name="x">1000</parameter>
+                </parameters>
+            </command>
+        </commands>
+    </format>
+</formats>
+


### PR DESCRIPTION
This PR adds a json endpoint accessible on `/.json` for the startpage, which will serve the picture URLs for the animation on the agent18 website.